### PR TITLE
[어드민] 뷰 엔드포인트 테스트 정의

### DIFF
--- a/src/main/java/com/fastcampus/projectboardadmin/controller/AdminUserAccountController.java
+++ b/src/main/java/com/fastcampus/projectboardadmin/controller/AdminUserAccountController.java
@@ -1,0 +1,21 @@
+package com.fastcampus.projectboardadmin.controller;
+
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+@RequestMapping("/admin/members")
+@Controller
+public class AdminUserAccountController {
+
+  public String members(
+      @PageableDefault(size = 10, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable,
+      Model model
+  ){
+    return "admin/members";
+  }
+
+}

--- a/src/main/java/com/fastcampus/projectboardadmin/controller/ArticleCommentManagementController.java
+++ b/src/main/java/com/fastcampus/projectboardadmin/controller/ArticleCommentManagementController.java
@@ -1,0 +1,21 @@
+package com.fastcampus.projectboardadmin.controller;
+
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+@RequestMapping("/management/article-comments")
+@Controller
+public class ArticleCommentManagementController {
+
+  public String members(
+      @PageableDefault(size = 10, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable,
+      Model model
+  ) {
+    return "management/articleComments";
+  }
+
+}

--- a/src/main/java/com/fastcampus/projectboardadmin/controller/ArticleManagementController.java
+++ b/src/main/java/com/fastcampus/projectboardadmin/controller/ArticleManagementController.java
@@ -1,0 +1,20 @@
+package com.fastcampus.projectboardadmin.controller;
+
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+@RequestMapping("/management/articles")
+@Controller
+public class ArticleManagementController {
+
+  public String members(
+      @PageableDefault(size = 10, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable,
+      Model model
+  ) {
+    return "management/articles";
+  }
+}

--- a/src/main/java/com/fastcampus/projectboardadmin/controller/MainController.java
+++ b/src/main/java/com/fastcampus/projectboardadmin/controller/MainController.java
@@ -1,0 +1,14 @@
+package com.fastcampus.projectboardadmin.controller;
+
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+
+@Controller
+public class MainController {
+
+  @GetMapping("/")
+  public String root(){
+    return "forward:/management/articles";
+  }
+
+}

--- a/src/main/java/com/fastcampus/projectboardadmin/controller/UserAccountManagementController.java
+++ b/src/main/java/com/fastcampus/projectboardadmin/controller/UserAccountManagementController.java
@@ -1,0 +1,21 @@
+package com.fastcampus.projectboardadmin.controller;
+
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+@RequestMapping("/management/user-accounts")
+@Controller
+public class UserAccountManagementController {
+
+  public String members(
+      @PageableDefault(size = 10, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable,
+      Model model
+  ) {
+    return "management/userAccounts";
+  }
+
+}

--- a/src/main/resources/templates/admin/members.html
+++ b/src/main/resources/templates/admin/members.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+  <meta charset="UTF-8">
+  <title>Title</title>
+</head>
+<body>
+
+</body>
+</html>

--- a/src/main/resources/templates/management/articleComments.html
+++ b/src/main/resources/templates/management/articleComments.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+  <meta charset="UTF-8">
+  <title>Title</title>
+</head>
+<body>
+
+</body>
+</html>

--- a/src/main/resources/templates/management/articles.html
+++ b/src/main/resources/templates/management/articles.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+  <meta charset="UTF-8">
+  <title>Title</title>
+</head>
+<body>
+
+</body>
+</html>

--- a/src/main/resources/templates/management/userAccounts.html
+++ b/src/main/resources/templates/management/userAccounts.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+  <meta charset="UTF-8">
+  <title>Title</title>
+</head>
+<body>
+
+</body>
+</html>

--- a/src/test/java/com/fastcampus/projectboardadmin/controller/AdminUserAccountControllerTest.java
+++ b/src/test/java/com/fastcampus/projectboardadmin/controller/AdminUserAccountControllerTest.java
@@ -1,0 +1,41 @@
+package com.fastcampus.projectboardadmin.controller;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.view;
+
+import com.fastcampus.projectboardadmin.config.SecurityConfig;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+@DisplayName("View 컨트롤러 - 어드민 회원")
+@Import(SecurityConfig.class)
+@WebMvcTest(AdminUserAccountController.class)
+class AdminUserAccountControllerTest {
+
+  private final MockMvc mvc;
+
+  public AdminUserAccountControllerTest(@Autowired MockMvc mvc) {
+    this.mvc = mvc;
+  }
+
+  @DisplayName(("[view][GET] 어드민 회원 페이지 - 정상 호출"))
+  @Test
+  void givenNothing_whenRequestingAdminMembersView_thenReturnsAdminMembersView() throws Exception {
+    // Given
+
+    // When & Then
+    mvc.perform(get("/admin/members"))
+        .andExpect(status().isOk())
+        .andExpect(content().contentTypeCompatibleWith(MediaType.TEXT_HTML))
+        .andExpect(view().name("admin/members"));
+
+  }
+
+}

--- a/src/test/java/com/fastcampus/projectboardadmin/controller/ArticleCommentManagementControllerTest.java
+++ b/src/test/java/com/fastcampus/projectboardadmin/controller/ArticleCommentManagementControllerTest.java
@@ -1,0 +1,41 @@
+package com.fastcampus.projectboardadmin.controller;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.view;
+
+import com.fastcampus.projectboardadmin.config.SecurityConfig;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+@DisplayName("View 컨트롤러 - 댓글 관리")
+@Import(SecurityConfig.class)
+@WebMvcTest(ArticleCommentManagementController.class)
+class ArticleCommentManagementControllerTest {
+
+  private final MockMvc mvc;
+
+  public ArticleCommentManagementControllerTest(@Autowired MockMvc mvc) {
+    this.mvc = mvc;
+  }
+
+  @DisplayName(("[view][GET] 댓글 관리 페이지 - 정상 호출"))
+  @Test
+  void givenNothing_whenRequestingArticleCommentsanagementView_thenReturnsArticleCommentsManagementView() throws Exception {
+    // Given
+
+    // When & Then
+    mvc.perform(get("/management/article-comments"))
+        .andExpect(status().isOk())
+        .andExpect(content().contentTypeCompatibleWith(MediaType.TEXT_HTML))
+        .andExpect(view().name("management/articleComments"));
+
+  }
+
+}

--- a/src/test/java/com/fastcampus/projectboardadmin/controller/ArticleManagementControllerTest.java
+++ b/src/test/java/com/fastcampus/projectboardadmin/controller/ArticleManagementControllerTest.java
@@ -1,0 +1,41 @@
+package com.fastcampus.projectboardadmin.controller;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.model;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.view;
+
+import com.fastcampus.projectboardadmin.config.SecurityConfig;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.web.servlet.MockMvc;
+
+@DisplayName("View 컨트롤러 - 게시글 관리")
+@Import(SecurityConfig.class)
+@WebMvcTest(ArticleManagementController.class)
+class ArticleManagementControllerTest {
+
+  private final MockMvc mvc;
+
+  public ArticleManagementControllerTest(@Autowired MockMvc mvc) {
+    this.mvc = mvc;
+  }
+
+  @DisplayName(("[view][GET] 게시글 관리 페이지 - 정상 호출"))
+  @Test
+  void givenNothing_whenRequestingArticleManagementView_thenReturns() throws Exception {
+    // Given
+
+    // When & Then
+    mvc.perform(get("/management/articles"))
+        .andExpect(status().isOk())
+        .andExpect(view().name("management/articles"))
+        .andExpect(model().attribute("articles", List.of()));
+
+  }
+
+}

--- a/src/test/java/com/fastcampus/projectboardadmin/controller/MainControllerTest.java
+++ b/src/test/java/com/fastcampus/projectboardadmin/controller/MainControllerTest.java
@@ -1,0 +1,44 @@
+package com.fastcampus.projectboardadmin.controller;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.forwardedUrl;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.view;
+
+import com.fastcampus.projectboardadmin.config.SecurityConfig;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
+
+@DisplayName("View 루트 컨트롤러")
+@Import(SecurityConfig.class)
+@WebMvcTest(MainController.class)
+class MainControllerTest {
+
+  private final MockMvc mvc;
+
+  public MainControllerTest(@Autowired MockMvc mvc) {
+    this.mvc = mvc;
+  }
+
+  @DisplayName(("[view][GET] 루트 페이지 -> 게시글 관리 페이지 Forwarding"))
+  @Test
+  void givenNothing_whenRequestingRootView_thenForwardsToArticleManagementView() throws Exception {
+    // Given
+
+    // When & Then
+    mvc.perform(get("/"))
+        .andExpect(status().isOk())
+        .andExpect(view().name("forward:/management/articles"))
+        .andExpect(forwardedUrl("/management/articles"));
+
+
+  }
+
+}

--- a/src/test/java/com/fastcampus/projectboardadmin/controller/UserAccountManagementControllerTest.java
+++ b/src/test/java/com/fastcampus/projectboardadmin/controller/UserAccountManagementControllerTest.java
@@ -1,0 +1,41 @@
+package com.fastcampus.projectboardadmin.controller;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.view;
+
+import com.fastcampus.projectboardadmin.config.SecurityConfig;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+@DisplayName("View 컨트롤러 - 회원 관리")
+@Import(SecurityConfig.class)
+@WebMvcTest(UserAccountManagementController.class)
+class UserAccountManagementControllerTest {
+
+  private final MockMvc mvc;
+
+  public UserAccountManagementControllerTest(@Autowired MockMvc mvc) {
+    this.mvc = mvc;
+  }
+
+  @DisplayName(("[view][GET] 어드민 회원 페이지 - 정상 호출"))
+  @Test
+  void givenNothing_whenRequestingAdminMembersView_thenReturnsAdminMembersView() throws Exception {
+    // Given
+
+    // When & Then
+    mvc.perform(get("/admin/members"))
+        .andExpect(status().isOk())
+        .andExpect(content().contentTypeCompatibleWith(MediaType.TEXT_HTML))
+        .andExpect(view().name("admin/members"));
+
+  }
+
+}


### PR DESCRIPTION
뷰 엔드포인트 5개를 위한 컨트롤러와 정상 테스트, 기초 뷰 파일을 추가함.
구체적인 구현이나 표현을 담고 있지 않으므로 앞으로 디테일한 내용을 개발해서 넣어줘야함.

This closes #8 