### PR TITLE
[어드민] 댓글 관리 페이지 기능 테스트 정의

### DIFF
--- a/src/main/java/com/fastcampus/projectboardadmin/dto/ArticleCommentDto.java
+++ b/src/main/java/com/fastcampus/projectboardadmin/dto/ArticleCommentDto.java
@@ -1,0 +1,21 @@
+package com.fastcampus.projectboardadmin.dto;
+
+import java.time.LocalDateTime;
+
+public record ArticleCommentDto(
+    Long id,
+    Long articleId,
+    UserAccountDto userAccount,
+    Long parentCommentId,
+    String content,
+    LocalDateTime createdAt,
+    String createdBy,
+    LocalDateTime modifiedAt,
+    String modifiedBy
+) {
+
+  public static ArticleCommentDto of(Long id, Long articleId, UserAccountDto userAccountDto, Long parentCommentId, String content, LocalDateTime createdAt, String createdBy, LocalDateTime modifiedAt,
+      String modifiedBy) {
+    return new ArticleCommentDto(id, articleId, userAccountDto, parentCommentId, content, createdAt, createdBy, modifiedAt, modifiedBy);
+  }
+}

--- a/src/main/java/com/fastcampus/projectboardadmin/dto/response/ArticleCommentClientResponse.java
+++ b/src/main/java/com/fastcampus/projectboardadmin/dto/response/ArticleCommentClientResponse.java
@@ -1,0 +1,43 @@
+package com.fastcampus.projectboardadmin.dto.response;
+
+import com.fastcampus.projectboardadmin.dto.ArticleCommentDto;
+import com.fastcampus.projectboardadmin.dto.ArticleDto;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.List;
+
+public record ArticleCommentClientResponse(
+    @JsonProperty("_embedded") Embedded embedded,
+
+    @JsonProperty("page") Page page
+
+) {
+
+  public static ArticleCommentClientResponse empty() {
+    return new ArticleCommentClientResponse(
+        new Embedded(List.of()),
+        new Page(1, 0, 1, 0)
+    );
+  }
+
+  public static ArticleCommentClientResponse of(List<ArticleCommentDto> articleComments) {
+    return new ArticleCommentClientResponse(
+        new Embedded(articleComments),
+        new Page(articleComments.size(), articleComments.size(), 1, 0)
+    );
+  }
+
+  public List<ArticleCommentDto> articleComments() {
+    return this.embedded().articleComments();
+  }
+
+  public record Embedded(List<ArticleCommentDto> articleComments) {
+
+  }
+
+  public record Page(
+      int size, long totalElements, int totalPages, int number
+  ) {
+
+  }
+
+}

--- a/src/main/java/com/fastcampus/projectboardadmin/service/ArticleCommentManagementService.java
+++ b/src/main/java/com/fastcampus/projectboardadmin/service/ArticleCommentManagementService.java
@@ -1,0 +1,25 @@
+package com.fastcampus.projectboardadmin.service;
+
+import com.fastcampus.projectboardadmin.dto.ArticleCommentDto;
+import com.fastcampus.projectboardadmin.dto.ArticleDto;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@RequiredArgsConstructor
+@Service
+public class ArticleCommentManagementService {
+
+  public List<ArticleCommentDto> getArticleComments() {
+    return List.of();
+  }
+
+  public ArticleCommentDto getArticleComment(Long articleCommentId) {
+    return null;
+  }
+
+  public void deleteArticleComment(Long articleId) {
+
+  }
+
+}

--- a/src/test/java/com/fastcampus/projectboardadmin/controller/ArticleCommentManagementControllerTest.java
+++ b/src/test/java/com/fastcampus/projectboardadmin/controller/ArticleCommentManagementControllerTest.java
@@ -1,15 +1,29 @@
 package com.fastcampus.projectboardadmin.controller;
 
+import static org.mockito.BDDMockito.*;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.model;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.redirectedUrl;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.view;
 
 import com.fastcampus.projectboardadmin.config.SecurityConfig;
+import com.fastcampus.projectboardadmin.domain.constant.RoleType;
+import com.fastcampus.projectboardadmin.dto.ArticleCommentDto;
+import com.fastcampus.projectboardadmin.dto.UserAccountDto;
+import com.fastcampus.projectboardadmin.service.ArticleCommentManagementService;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Set;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Import;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
@@ -21,6 +35,8 @@ class ArticleCommentManagementControllerTest {
 
   private final MockMvc mvc;
 
+  @MockBean private ArticleCommentManagementService articleCommentManagementService;
+
   public ArticleCommentManagementControllerTest(@Autowired MockMvc mvc) {
     this.mvc = mvc;
   }
@@ -29,13 +45,77 @@ class ArticleCommentManagementControllerTest {
   @Test
   void givenNothing_whenRequestingArticleCommentsanagementView_thenReturnsArticleCommentsManagementView() throws Exception {
     // Given
+    given(articleCommentManagementService.getArticleComments()).willReturn(List.of());
 
     // When & Then
     mvc.perform(get("/management/article-comments"))
         .andExpect(status().isOk())
         .andExpect(content().contentTypeCompatibleWith(MediaType.TEXT_HTML))
-        .andExpect(view().name("management/article-comments"));
+        .andExpect(view().name("management/article-comments"))
+        .andExpect(model().attribute("comments",List.of()));
+    then(articleCommentManagementService).should().getArticleComments();
 
+  }
+
+  @DisplayName("[data][GET] 댓글 1개 - 정상 호출")
+  @Test
+  void givenCommentId_whenRequestingArticleComment_thenReturnsArticleComment() throws Exception {
+    // Given
+    Long articleCommentId = 1L;
+    ArticleCommentDto articleCommentDto = createArticleCommentDto("comment");
+    given(articleCommentManagementService.getArticleComment(articleCommentId)).willReturn(articleCommentDto);
+
+    // When & Then
+    mvc.perform(get("/management/article-comments/" + articleCommentId))
+        .andExpect(status().isOk())
+        .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+        .andExpect(jsonPath("$.id").value(articleCommentId))
+        .andExpect(jsonPath("$.content").value(articleCommentDto.content()))
+        .andExpect(jsonPath("$.userAccount.nickname").value(articleCommentDto.userAccount().nickname()));
+    then(articleCommentManagementService).should().getArticleComment(articleCommentId);
+  }
+
+  @DisplayName("[view][POST] 댓글 삭제 - 정상 호출")
+  @Test
+  void givenCommentId_whenRequestingDeletion_thenRedirectsToArticleCommentManagementView() throws Exception {
+    // Given
+    Long articleCommentId = 1L;
+    willDoNothing().given(articleCommentManagementService).deleteArticleComment(articleCommentId);
+
+    // When & Then
+    mvc.perform(
+            post("/management/article-comments/" + articleCommentId)
+                .with(csrf())
+        )
+        .andExpect(status().is3xxRedirection())
+        .andExpect(view().name("redirect:/management/article-comments"))
+        .andExpect(redirectedUrl("/management/article-comments"));
+    then(articleCommentManagementService).should().deleteArticleComment(articleCommentId);
+  }
+
+  private ArticleCommentDto createArticleCommentDto(String content) {
+    return ArticleCommentDto.of(
+        1L,
+        1L,
+        createUserAccountDto(),
+        null,
+        content,
+        LocalDateTime.now(),
+        "Admin1",
+        LocalDateTime.now(),
+        "Admin1"
+    );
+  }
+
+  private UserAccountDto createUserAccountDto() {
+    return UserAccountDto.of(
+        "jackieTest",
+        "pw",
+        Set.of(RoleType.ADMIN),
+        "jackie-test@email.com",
+        "jackie-test",
+        "test memo"
+    );
   }
 
 }

--- a/src/test/java/com/fastcampus/projectboardadmin/service/ArticleCommentManagementServiceTest.java
+++ b/src/test/java/com/fastcampus/projectboardadmin/service/ArticleCommentManagementServiceTest.java
@@ -1,0 +1,184 @@
+package com.fastcampus.projectboardadmin.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.method;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withSuccess;
+
+import com.fastcampus.projectboardadmin.domain.constant.RoleType;
+import com.fastcampus.projectboardadmin.dto.ArticleCommentDto;
+import com.fastcampus.projectboardadmin.dto.ArticleDto;
+import com.fastcampus.projectboardadmin.dto.UserAccountDto;
+import com.fastcampus.projectboardadmin.dto.properties.ProjectProperties;
+import com.fastcampus.projectboardadmin.dto.response.ArticleClientResponse;
+import com.fastcampus.projectboardadmin.dto.response.ArticleCommentClientResponse;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Set;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.boot.test.autoconfigure.web.client.AutoConfigureWebClient;
+import org.springframework.boot.test.autoconfigure.web.client.RestClientTest;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.client.MockRestServiceServer;
+
+@ActiveProfiles("test")
+@DisplayName("비즈니스 로직 - 댓글 관리")
+class ArticleCommentManagementServiceTest {
+
+  //@Disabled("실제 호출 API 결과 관찰용이므로 평상시에는 비활성화")
+  @DisplayName("실제 API 호출 테스트")
+  @SpringBootTest
+  @Nested
+  class RealApiTest {
+
+    private final ArticleCommentManagementService sut;
+
+    @Autowired
+    public RealApiTest(ArticleCommentManagementService sut) {
+      this.sut = sut;
+    }
+
+    @DisplayName("댓글 API를 호출하면, 댓글들을 가져온다.")
+    @Test
+    void givenNothing_whenCallingComments_thenReturnsCommentList() {
+      // Given
+
+      // When
+      List<ArticleCommentDto> result = sut.getArticleComments();
+
+      // Then
+      System.out.println(result.stream().findFirst());
+      assertThat(result).isNotNull();
+    }
+
+  }
+
+  @DisplayName("API mocking 테스트")
+  @EnableConfigurationProperties(ProjectProperties.class)
+  @AutoConfigureWebClient(registerRestTemplate = true)
+  @RestClientTest(ArticleCommentManagementService.class)
+  @Nested
+  class RestTemplateTest {
+
+    private final ArticleCommentManagementService sut;
+    private final ProjectProperties projectProperties;
+    private final MockRestServiceServer server;
+    private final ObjectMapper mapper;
+
+    @Autowired
+    public RestTemplateTest(
+        ArticleCommentManagementService sut,
+        ProjectProperties projectProperties,
+        MockRestServiceServer server,
+        ObjectMapper mapper
+
+    ) {
+      this.sut = sut;
+      this.projectProperties = projectProperties;
+      this.server = server;
+      this.mapper = mapper;
+    }
+
+    @DisplayName("댓글 목록 API을 호출하면, 댓글들을 가져온다.")
+    @Test
+    void givenNothing_whenCallingCommentsApi_thenReturnsCommentList() throws Exception {
+      // Given
+      ArticleCommentDto expectedComment = createArticleCommentDto("댓글");
+      ArticleCommentClientResponse expectedResponse = ArticleCommentClientResponse.of(List.of(expectedComment));
+      server
+          .expect(requestTo(projectProperties.board().url() + "/api/articleComments?size=10000"))
+          .andRespond(withSuccess(
+              mapper.writeValueAsString(expectedResponse),
+              MediaType.APPLICATION_JSON
+          ));
+
+
+      // When
+      List<ArticleCommentDto> result = sut.getArticleComments();
+
+      // Then
+      assertThat(result).first()
+          .hasFieldOrPropertyWithValue("id", expectedComment.id())
+          .hasFieldOrPropertyWithValue("content", expectedComment.content())
+          .hasFieldOrPropertyWithValue("userAccount.nickname", expectedComment.userAccount().nickname());
+      server.verify();
+    }
+
+    @DisplayName("댓글 ID와 함께 댓글 API을 호출하면, 댓글을 가져온다.")
+    @Test
+    void givenCommentId_whenCallingCommentApi_thenReturnsComment() throws Exception {
+      // Given
+      Long articleCommentId = 1L;
+      ArticleCommentDto expectedComment = createArticleCommentDto("댓글");
+      server
+          .expect(requestTo(projectProperties.board().url() + "/api/articleComments/" + articleCommentId))
+          .andRespond(withSuccess(
+              mapper.writeValueAsString(expectedComment),
+              MediaType.APPLICATION_JSON
+          ));
+
+
+      // When
+      ArticleCommentDto result = sut.getArticleComment(articleCommentId);
+
+      // Then
+      assertThat(result)
+          .hasFieldOrPropertyWithValue("id", expectedComment.id())
+          .hasFieldOrPropertyWithValue("content", expectedComment.content())
+          .hasFieldOrPropertyWithValue("userAccount.nickname", expectedComment.userAccount().nickname());
+      server.verify();
+    }
+
+    @DisplayName("댓글 ID와 함께 댓글 삭제 API을 호출하면, 댓글을 삭제한다.")
+    @Test
+    void givenCommentId_whenCallingDeleteCommentApi_thenDeletesComment() throws Exception {
+      // Given
+      Long articleCommentId = 1L;
+      server
+          .expect(requestTo(projectProperties.board().url() + "/api/articleComments/" + articleCommentId))
+          .andExpect(method(HttpMethod.DELETE))
+          .andRespond(withSuccess());
+
+      // When
+      sut.deleteArticleComment(articleCommentId);
+
+      // Then
+      server.verify();
+    }
+  }
+
+
+  private ArticleCommentDto createArticleCommentDto(String content) {
+    return ArticleCommentDto.of(
+        1L,
+        1L,
+        createUserAccountDto(),
+        null,
+        content,
+        LocalDateTime.now(),
+        "Admin1",
+        LocalDateTime.now(),
+        "Admin1"
+    );
+  }
+
+  private UserAccountDto createUserAccountDto() {
+    return UserAccountDto.of(
+        "jackieTest",
+        "pw",
+        Set.of(RoleType.ADMIN),
+        "jackie-test@email.com",
+        "jackie-test",
+        "test memo"
+    );
+  }
+}

--- a/src/test/java/com/fastcampus/projectboardadmin/service/ArticleManagementServiceTest.java
+++ b/src/test/java/com/fastcampus/projectboardadmin/service/ArticleManagementServiceTest.java
@@ -47,7 +47,7 @@ class ArticleManagementServiceTest {
 
     @DisplayName("게시글 API를 호출하면, 게시글을 가져온다.")
     @Test
-    void given_when_then() {
+    void givenNothing_whenCallingArticles_thenReturnsArticlesList() {
       // Given
 
       // When


### PR DESCRIPTION
이 pr은 댓글 관리 페이지 기능을 구현하기 위한
비즈니스 로직과 컨트롤러의 테스트를 추가한다.

구현이 없으므로 테스트가 실패하는 상태이다.

This closes #15 
